### PR TITLE
Run with std input

### DIFF
--- a/Shelly.hs
+++ b/Shelly.hs
@@ -28,7 +28,7 @@ module Shelly
          , readfile, writefile, appendfile, withTmpDir
 
          -- * Running external commands.
-         , run, ( # ), run_, runStdin, command, command_, command1, command1_, lastStderr
+         , run, ( # ), run_, runStdin, runStdin_, command, command_, command1, command1_, lastStderr
 
          -- * exiting the program
          , exit, errorExit, terror
@@ -467,6 +467,10 @@ command1_ com args one_arg more_args = run_ com ([one_arg] ++ args ++ more_args)
 -- the same as "run", but return () instead of the stdout content
 run_ :: FilePath -> [Text] -> ShIO ()
 run_ = runFoldLines () (\(_, _) -> ())
+
+-- the same as "runStdin", but return () instead of the stdout content
+runStdin_ :: FilePath -> [Text] -> Text -> ShIO ()
+runStdin_ cmd args input = runFoldLines' () (\(_, _) -> ()) cmd args (Just input)
 
 liftIO_ :: IO a -> ShIO ()
 liftIO_ action = liftIO action >> return ()


### PR DESCRIPTION
I added functions runStdin and runStdin_ which take an extra Text argument.  This Text argument will be written to stdin of the process when it is executed.  Allows heredoc like behavior which is useful in some situations.

To implement this I created runFoldLines' which takes a (Maybe Text) argument compared to runFoldLines.  runfoldLines now calls out to runFoldLines' with a Nothing argument for the std input argument.  Not sure if this is the right way to do this but it seems clean.
