### PR TITLE
Support asynchronous background tasks.

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -34,7 +34,7 @@ Library
   Exposed-modules:     Shelly
 
   Build-depends: base >= 4 && < 5, time, directory, mtl, process, text, unix-compat
-               , system-filepath, system-fileio
+               , system-filepath, system-fileio, future >= 2.0
 
   ghc-options: -Wall
 


### PR DESCRIPTION
Hi Greg,
Not sure if you want something like this in Shelly or not but I've found it really useful. It allows backgrounding a task to run in parallel similarly to appending '&' to a command in the shell.  I used the future package though so you still have access to the command output.  I also added an option in the ShIO monad for the maximum number of background jobs running simultaneously.  I found this useful when I had a few hundred memory expensive jobs and didn't want to micromanage the partitioning of them.

Great work on Shelly btw, I really like it.
Andrew

Add `background` a function for backgrounding ShIO tasks.  There is
now a dependency on the future package.  background uses future to spawn
tasks in a differnent thread.  It returns a promise which can be extracted
using the future API.  Also alias and reexport Future.get to getPromise
for convienence.
