### PR TITLE
Be able to background tasks that will live on

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -34,7 +34,7 @@ Library
   Exposed-modules:     Shelly
 
   Build-depends: base >= 4 && < 5, time, directory, mtl, process, text, unix-compat
-               , system-filepath, system-fileio
+               , system-filepath, system-fileio, unix
 
   ghc-options: -Wall
 


### PR DESCRIPTION
I needed this about 2 seconds into trying out Shelly as a bash-replacement for my yesod-related deployment scripts.

I need to spawn my warp workers to the background and I don't want the script to wait around for them. So I put in something quick that allows me to do this:

``` .haskell
bg $ run_ "./dist/build/site/site" ["-p", "3001", "production"]
```

I fear this isn't the best way to do it though (it relies on unix:forkProcess) but I figured I'd share it with you via pull req and at least get some discussion going.

I did read the other open issue/pull request but it seems like a separate idea with different goals. Not sure if these two features could be implemented together.
