### PR TITLE
add TypeSynonymInstances to support GHC 7.0

### DIFF
--- a/Shelly.hs
+++ b/Shelly.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, OverloadedStrings,
-             MultiParamTypeClasses, FlexibleInstances #-}
+             MultiParamTypeClasses, FlexibleInstances, TypeSynonymInstances #-}
 
 -- | A module for shell-like / perl-like programming in Haskell.
 -- Shelly's focus is entirely on ease of use for those coming from shell scripting.


### PR DESCRIPTION
GHC 7 requires the TypeSynonymInstances extension to compile shelly
