### PR TITLE
Add missing Shelly import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ They take a FilePath as their first argument. `run` takes a [Text] as its second
     {-# LANGUAGE OverloadedStrings #-}
     {-# LANGUAGE ExtendedDefaultRules #-}
     {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+    import Shelly
     import Data.Text.Lazy as LT
     default (LT.Text)
 

--- a/Shelly.hs
+++ b/Shelly.hs
@@ -19,6 +19,7 @@
 -- > {-# LANGUAGE OverloadedStrings #-}
 -- > {-# LANGUAGE ExtendedDefaultRules #-}
 -- > {-# OPTIONS_GHC -fno-warn-type-defaults #-}
+-- > import Shelly
 -- > import Data.Text.Lazy as LT
 -- > default (LT.Text)
 module Shelly


### PR DESCRIPTION
Documentation suggests `import Shelly'. Without that line programs can't
compile.
