### PR TITLE
Fix runFoldLines' tracing

### DIFF
--- a/Shelly.hs
+++ b/Shelly.hs
@@ -812,7 +812,7 @@ runFoldLines start cb exe args = do
                  ExitSuccess -> 0
                  ExitFailure n -> n
 
-    put $ state { sStderr = errs , sCode = code }
+    modify $ \state' -> state' { sStderr = errs , sCode = code }
 
     liftIO $ case (sErrExit state, ex) of
       (True,  ExitFailure n) -> throwIO $ RunFailed exe args n errs


### PR DESCRIPTION
It was broken by 3af871b93d24dbc19386308a1ec3edd3ac15032a some months ago.
