### PR TITLE
Updates for Shelly.Pipe

### DIFF
--- a/Shelly.hs
+++ b/Shelly.hs
@@ -51,7 +51,7 @@ module Shelly
          , hasExt
 
          -- * Manipulating filesystem.
-         , mv, rm, rm_f, rm_rf, cp, cp_r, mkdir, mkdir_p
+         , mv, rm, rm_f, rm_rf, cp, cp_r, mkdir, mkdir_p, mkdirTree
 
          -- * reading/writing Files
          , readfile, readBinary, writefile, appendfile, touchfile, withTmpDir
@@ -114,6 +114,8 @@ import qualified Filesystem.Path.CurrentOS as FP
 
 import System.Directory ( setPermissions, getPermissions, Permissions(..), getTemporaryDirectory, findExecutable )
 import Data.Char (isDigit)
+
+import Data.Tree(Tree(..))
 
 {- GHC won't default to Text with this, even with extensions!
  - see: http://hackage.haskell.org/trac/ghc/ticket/6030
@@ -403,6 +405,33 @@ mkdir_p :: FilePath -> Sh ()
 mkdir_p = absPath >=> \fp -> do
   trace $ "mkdir -p " `mappend` toTextIgnore fp
   liftIO $ createTree fp
+
+-- | Create a new directory tree. You can describe a bunch of directories as 
+-- a tree and this function will create all subdirectories. An example:
+--
+-- > exec = mkTree $
+-- >           "package" # [
+-- >                "src" # [
+-- >                    "Data" # leaves ["Tree", "List", "Set", "Map"] 
+-- >                ],
+-- >                "test" # leaves ["QuickCheck", "HUnit"],
+-- >                "dist/doc/html" # []
+-- >            ]
+-- >         where (#) = Node
+-- >               leaves = map (# []) 
+--
+mkdirTree :: Tree FilePath -> Sh ()
+mkdirTree = mk . unrollPath 
+    where mk :: Tree FilePath -> Sh ()
+          mk (Node a ts) = do
+            b <- test_d a
+            unless b $ mkdir a
+            chdir a $ mapM_ mkdirTree ts
+            
+          unrollPath :: Tree FilePath -> Tree FilePath
+          unrollPath (Node v ts) = unrollRoot v $ map unrollPath ts
+              where unrollRoot x = foldr1 phi $ map Node $ splitDirectories x
+                    phi a b = a . return . b
 
 -- | Get a full path to an executable on @PATH@, if exists. FIXME does not
 -- respect setenv'd environment and uses @findExecutable@ which uses the @PATH@ inherited from the process

--- a/Shelly/Pipe.hs
+++ b/Shelly/Pipe.hs
@@ -67,7 +67,7 @@ module Shelly.Pipe
          , hasExt
 
          -- * Manipulating filesystem.
-         , mv, rm, rm_f, rm_rf, cp, cp_r, mkdir, mkdir_p
+         , mv, rm, rm_f, rm_rf, cp, cp_r, mkdir, mkdir_p, mkdirTree
 
          -- * reading/writing Files
          , readfile, readBinary, writefile, appendfile, touchfile, withTmpDir
@@ -117,6 +117,8 @@ import Shelly(
 import Data.Maybe(fromMaybe)
 import Shelly.Base(State)
 import Data.ByteString (ByteString)
+
+import Data.Tree(Tree)
 
 import Data.Text.Lazy as LT hiding (concat, all, find, cons)
 
@@ -540,6 +542,23 @@ mkdir = sh1 S.mkdir
 -- already exists).
 mkdir_p :: FilePath -> Sh ()
 mkdir_p = sh1 S.mkdir_p
+
+-- | Create a new directory tree. You can describe a bunch of directories as 
+-- a tree and this function will create all subdirectories. An example:
+--
+-- > exec = mkTree $
+-- >           "package" # [
+-- >                "src" # [
+-- >                    "Data" # leaves ["Tree", "List", "Set", "Map"] 
+-- >                ],
+-- >                "test" # leaves ["QuickCheck", "HUnit"],
+-- >                "dist/doc/html" # []
+-- >            ]
+-- >         where (#) = Node
+-- >               leaves = map (# []) 
+--
+mkdirTree :: Tree FilePath -> Sh ()
+mkdirTree = sh1 S.mkdirTree
 
 -- | (Strictly) read file into a Text.
 -- All other functions use Lazy Text.

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -42,6 +42,7 @@ Library
                , system-filepath < 0.5
                , system-fileio < 0.4
                , bytestring
+               , containers
 
   ghc-options: -Wall
 


### PR DESCRIPTION
It fixes usage of deprecated function get_env_def and adds some new functions in Shelly.Pipe from the main Shelly module
