### PR TITLE
filter out carriage returns for readfile

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1187,7 +1187,7 @@ readfile :: FilePath -> Sh Text
 readfile = absPath >=> \fp -> do
   trace $ "readfile " <> toTextIgnore fp
   readBinary fp >>=
-    return . TE.decodeUtf8With TE.lenientDecode
+    return . T.filter (/='\r') . TE.decodeUtf8With TE.lenientDecode
 
 -- | wraps ByteSting readFile
 readBinary :: FilePath -> Sh ByteString


### PR DESCRIPTION
This is related to this pull request
https://github.com/yesodweb/shakespeare/pull/113 referrring to https://gist.github.com/gbwey/6833805

This change to readfile will filter out carriage returns as does Data.Text.IO.readFile.
Avoids the situation in windows where you read a file/then write it back and it is different.

Is there a reason why we don't just use Data.Text.IO.readFile?

Thanks,
Grant
