### PR TITLE
FIXED: "rm " instead of "rm"

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,6 +1,6 @@
 Name:       shelly
 
-Version:     1.4.0.1
+Version:     1.4.0.2
 Synopsis:    shell-like (systems) programming in Haskell
 
 Description: Shelly provides convenient systems programming in Haskell,

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -654,7 +654,7 @@ rm_f = absPath >=> \f -> do
 -- Does fail if the file does not exist (use 'rm_f' instead) or is not a file.
 rm :: FilePath -> Sh ()
 rm = absPath >=> \f -> do
-  trace $ "rm" <> toTextIgnore f
+  trace $ "rm " <> toTextIgnore f
   -- TODO: better error message for removeFile (give filename)
   canonic f >>= liftIO . removeFile
 


### PR DESCRIPTION
This small patch fixes the issue thatoccurs when using Shelly.rm method, and it tries to run "rm/filepath" instead of "rm /filepath".
