### PR TITLE
Add bracket_sh function

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -72,7 +72,7 @@ module Shelly
          , toTextIgnore, toTextWarn, fromText
 
          -- * Utility Functions
-         , whenM, unlessM, time, sleep 
+         , whenM, unlessM, time, sleep
 
          -- * Re-exported for your convenience
          , liftIO, when, unless, FilePath, (<$>)
@@ -516,28 +516,28 @@ mkdir_p = absPath >=> \fp -> do
   trace $ "mkdir -p " <> toTextIgnore fp
   liftIO $ createTree fp
 
--- | Create a new directory tree. You can describe a bunch of directories as 
+-- | Create a new directory tree. You can describe a bunch of directories as
 -- a tree and this function will create all subdirectories. An example:
 --
 -- > exec = mkTree $
 -- >           "package" # [
 -- >                "src" # [
--- >                    "Data" # leaves ["Tree", "List", "Set", "Map"] 
+-- >                    "Data" # leaves ["Tree", "List", "Set", "Map"]
 -- >                ],
 -- >                "test" # leaves ["QuickCheck", "HUnit"],
 -- >                "dist/doc/html" # []
 -- >            ]
 -- >         where (#) = Node
--- >               leaves = map (# []) 
+-- >               leaves = map (# [])
 --
 mkdirTree :: Tree FilePath -> Sh ()
-mkdirTree = mk . unrollPath 
+mkdirTree = mk . unrollPath
     where mk :: Tree FilePath -> Sh ()
           mk (Node a ts) = do
             b <- test_d a
             unless b $ mkdir a
             chdir a $ mapM_ mkdirTree ts
-            
+
           unrollPath :: Tree FilePath -> Tree FilePath
           unrollPath (Node v ts) = unrollRoot v $ map unrollPath ts
               where unrollRoot x = foldr1 phi $ map Node $ splitDirectories x
@@ -577,7 +577,7 @@ which originalFp = whichFull
             liftIO $ print pathExecutables
             return $ fmap (flip (</>) fp . fst) $
                 L.find (S.member fp . snd) pathExecutables
-        
+
 
         pathDirs = mapM absPath =<< ((map fromText . T.split (== searchPathSeparator)) `fmap` get_env_text "PATH")
 
@@ -777,7 +777,7 @@ sub a = do
       newState <- get
       put oldState {
          -- avoid losing the log
-         sTrace  = sTrace oldState <> sTrace newState 
+         sTrace  = sTrace oldState <> sTrace newState
          -- latest command execution: not make sense to restore these to old settings
        , sCode   = sCode newState
        , sStderr = sStderr newState
@@ -818,7 +818,7 @@ errExit shouldExit action = sub $ do
 data ShellyOpts = ShellyOpts { failToDir :: Bool }
 
 -- avoid data-default dependency for now
--- instance Default ShellyOpts where 
+-- instance Default ShellyOpts where
 shellyOpts :: ShellyOpts
 shellyOpts = ShellyOpts { failToDir = True }
 
@@ -1027,7 +1027,7 @@ runHandle :: FilePath -- ^ command
           -> [Text] -- ^ arguments
           -> (Handle -> Sh a) -- ^ stdout handle
           -> Sh a
-runHandle exe args withHandle = 
+runHandle exe args withHandle =
   runHandles exe args [] $ \_ outH errH -> do
     errVar <- liftIO $ do
       errVar' <- newEmptyMVar
@@ -1094,7 +1094,7 @@ runHandles exe args reusedHandles withHandles = do
   where -- Windows does not terminate spawned processes, so we must bracket.
 #if defined(mingw32_HOST_OS)
     bracketOnWindowsError acquire release main = do
-      resource <- acquire 
+      resource <- acquire
       main resource `catchany_sh` (\e -> do
           _ <- release resource
           liftIO $ throwIO e


### PR DESCRIPTION
Hello,

I took the liberty to add the bracket_sh function. We are playing with the notion of background processes on our shelly scripts, and we noticed that when doing them they were not being cleaned up correctly. After adding this patch things worked as expected.

NOTE: Changes were tested with shelly-testsuite

Also, emacs removed some trailing whitespaces that were around the code.

Cheers.
