### PR TITLE
Reduce containers lower bound to ghc-7.4.2 version

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -38,7 +38,7 @@ Library
   hs-source-dirs: src
 
   Build-depends:
-    containers                >= 0.5.0.0,
+    containers                >= 0.4.2.0,
     time                      >= 1.3 && < 1.5,
     directory                 >= 1.1.0.0 && < 1.3.0.0,
     mtl                       >= 2,


### PR DESCRIPTION
So it builds with the version included with GHC 7.4.2
