### PR TITLE
Add support for a custom output writer

### DIFF
--- a/src/Shelly/Base.hs
+++ b/src/Shelly/Base.hs
@@ -95,10 +95,11 @@ runSh :: Sh a -> IORef State -> IO a
 runSh = runReaderT . unSh
 
 data ReadOnlyState = ReadOnlyState { rosFailToDir :: Bool }
-data State = State 
+data State = State
    { sCode :: Int -- ^ exit code for command that ran
    , sStdin :: Maybe Text -- ^ stdin for the command to be run
    , sStderr :: Text -- ^ stderr for command that ran
+   , sOutputWriter :: Handle -> Text -> IO ()
    , sDirectory :: FilePath -- ^ working directory
    , sPrintStdout :: Bool   -- ^ print stdout of command that is executed
    , sPrintStderr :: Bool   -- ^ print stderr of command that is executed
@@ -230,12 +231,12 @@ gets f = f <$> get
 
 get :: Sh State
 get = do
-  stateVar <- ask 
+  stateVar <- ask
   liftIO (readIORef stateVar)
 
 modify :: (State -> State) -> Sh ()
 modify f = do
-  state <- ask 
+  state <- ask
   liftIO (modifyIORef state f)
 
 -- | internally log what occurred.
@@ -297,4 +298,3 @@ traceLiftIO f msg = trace ("echo " `mappend` "'" `mappend` msg `mappend` "'") >>
 -- @... `catch` \(e :: SomeException) -> ...@).
 catchany :: IO a -> (SomeException -> IO a) -> IO a
 catchany = catch
-

--- a/src/Shelly/Lifted.hs
+++ b/src/Shelly/Lifted.hs
@@ -354,8 +354,10 @@ time what = controlSh $ \runInSh -> do
 toTextWarn :: MonadSh m => FilePath -> m Text
 toTextWarn = liftSh . toTextWarn
 
-transferLinesAndCombine :: MonadIO m => Handle -> Handle -> m Text
-transferLinesAndCombine = (liftIO .) . S.transferLinesAndCombine
+transferLinesAndCombine :: MonadIO m
+                        => (Handle -> Text -> IO ()) -> Handle -> Handle -> m Text
+transferLinesAndCombine writer h1 h2 =
+  liftIO $ S.transferLinesAndCombine writer h1 h2
 
 get :: MonadSh m => m S.State
 get = liftSh S.get

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -30,14 +30,14 @@ findSpec = do
       sort res @?= ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./MoveSpec.hs",
                     "./ReadFileSpec.hs", "./RmSpec.hs", "./TestInit.hs", "./TestMain.hs",
-                    "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
+                    "./WhichSpec.hs", "./WriteSpec.hs", "./WriterSpec.hs", "./sleep.hs"]
 
     it "finds relative files" $ do
       res <- shelly $ cd "src" >> find "."
       sort res @?= ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./MoveSpec.hs",
                     "./ReadFileSpec.hs", "./RmSpec.hs", "./TestInit.hs", "./TestMain.hs",
-                    "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
+                    "./WhichSpec.hs", "./WriteSpec.hs", "./WriterSpec.hs", "./sleep.hs"]
 
   describe "find" $ do
     it "empty list for empty dir" $ do
@@ -51,13 +51,15 @@ findSpec = do
 
     it "lists relative files" $ do
       res <- shelly $ find "src"
-      sort res @?= ["src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs",
-                    "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs", "src/MoveSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs",
-                    "src/TestInit.hs", "src/TestMain.hs", "src/WhichSpec.hs", "src/WriteSpec.hs",
-                    "src/sleep.hs"]
+      sort res @?= [ "src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs"
+                   , "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs"
+                   , "src/MoveSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs"
+                   , "src/TestInit.hs", "src/TestMain.hs", "src/WhichSpec.hs"
+                   , "src/WriteSpec.hs", "src/WriterSpec.hs", "src/sleep.hs"]
 
     it "lists absolute files" $ do
       res <- shelly $ relPath "src" >>= find >>= mapM (relativeTo "src")
-      sort res @?= ["CopySpec.hs", "EnvSpec.hs", "FailureSpec.hs", "FindSpec.hs",
-                    "Help.hs", "LiftedSpec.hs", "MoveSpec.hs", "ReadFileSpec.hs", "RmSpec.hs", "TestInit.hs", "TestMain.hs",
-                    "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
+      sort res @?= [ "CopySpec.hs", "EnvSpec.hs", "FailureSpec.hs", "FindSpec.hs"
+                   , "Help.hs", "LiftedSpec.hs", "MoveSpec.hs", "ReadFileSpec.hs"
+                   , "RmSpec.hs", "TestInit.hs", "TestMain.hs", "WhichSpec.hs"
+                   ,  "WriteSpec.hs", "WriterSpec.hs", "sleep.hs"]

--- a/test/src/TestMain.hs
+++ b/test/src/TestMain.hs
@@ -1,9 +1,9 @@
-
 module Main where
 
 import ReadFileSpec
 import WhichSpec
 import WriteSpec
+import WriterSpec
 import MoveSpec
 import RmSpec
 import FindSpec
@@ -19,6 +19,7 @@ main = hspec $ do
     readFileSpec
     whichSpec
     writeSpec
+    writerSpec
     moveSpec
     rmSpec
     findSpec

--- a/test/src/WriterSpec.hs
+++ b/test/src/WriterSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module WriterSpec ( writerSpec ) where
+
+import TestInit
+import Prelude hiding (FilePath)
+
+import Control.Concurrent (newEmptyMVar, takeMVar, putMVar)
+import Data.Text (Text)
+default (Text)
+
+writerSpec :: Spec
+writerSpec =
+  describe "withOutputWriter" $
+    it "calls writer function with handler and stdout output" $ do
+      outputVar <- newEmptyMVar
+      shelly
+        . withOutputWriter (const $ putMVar outputVar)
+        $ run_ "echo" ["single line output"]
+      result <- takeMVar outputVar
+      assertEqual "expecting output" "single line output" result


### PR DESCRIPTION
In some cases it is useful to redirect the output of a command to a
logger instead of printing the output to stdout/stderr. With this
patch you may now indicate an IO action that gets executed whenever
Shelly prints output.

Example:

``` haskell
main :: IO ()
main = do
   logger < createLogger
   shelly
     . withOutputWriter (\_handle output -> debug logger output)
     $ run_ "superDuperOutputCommand" ["--foo", "--bar"]
```
