### PR TITLE
Fixed error where certain values of $PATH would raise an exception

### DIFF
--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -604,7 +604,7 @@ which originalFp = whichFull
                 L.find (S.member fp . snd) pathExecutables
 
 
-        pathDirs = mapM absPath =<< ((map FP.fromText . T.split (== searchPathSeparator)) `fmap` get_env_text "PATH")
+        pathDirs = mapM absPath =<< ((map FP.fromText . filter (not . T.null) . T.split (== searchPathSeparator)) `fmap` get_env_text "PATH")
 
         cachedPathExecutables :: Sh [(FilePath, S.Set FilePath)]
         cachedPathExecutables = do


### PR DESCRIPTION
It might have just been something weird about my Windows machine's PATH, but absPath was raising an exception because it was passed an empty filepath. Filtering for nonempty filepaths fixes the issue.
