### PR TITLE
Silence warnings for GHC 8.0 - 9.2; package lower bounds

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -65,28 +65,37 @@ Library
 
   hs-source-dirs: src
 
+  -- Andreas Abel, 2021-11-20:
+  -- Unless other constraints exist, lower bounds are chosen
+  -- such that all versions that build with GHC 8
+  -- (according to matrix.hackage.haskell.org) are included.
   Build-depends:
-      base                      >= 4.9 && < 5
+      base                      >= 4.9       && < 5
+        -- support GHC >= 8
     , async
-    , bytestring
-    , containers                >= 0.4.2.0
-    , directory                 >= 1.3.0.0 && < 1.4.0.0
+    , bytestring                >= 0.10.6.0
+    , containers                >= 0.5.7.0
+    , directory                 >= 1.3.0.0   && < 1.4.0.0
     , enclosed-exceptions
-    , exceptions                >= 0.6
+    , exceptions                >= 0.8.2.1
     , filepath
     , lifted-async
-    , lifted-base
-    , monad-control             >= 0.3.2 && < 1.1
-    , mtl                       >= 2
-    , process                   >= 1.0
-    , text
-    , time                      >= 1.3 && < 1.13
-    , transformers
+    , lifted-base               >= 0.2.3.2
+    , monad-control             >= 0.3.2     && < 1.1
+    , mtl                       >= 2.2.2
+    , process                   >= 1.4
+    , text                      >= 1.2.2.0
+    , time                      >= 1.3       && < 1.13
+    , transformers              >= 0.5.0.0
     , transformers-base
-    , unix-compat               < 0.6
+    , unix-compat               >= 0.4.1.1   && < 0.6
 
-  ghc-options: -Wall
-  cpp-options: -DNO_PRELUDE_CATCH
+  ghc-options:
+    -Wall
+    -Wcompat
+
+  cpp-options:
+    -DNO_PRELUDE_CATCH
 
   extensions:
     CPP
@@ -120,11 +129,11 @@ Test-Suite shelly-testsuite
     WriteSpec
 
   ghc-options:
+    -threaded
     -Wall
+    -Wcompat
     -fwarn-tabs
     -funbox-strict-fields
-    -threaded
-    -fno-warn-unused-do-bind
     -fno-warn-type-defaults
 
   extensions:
@@ -136,18 +145,19 @@ Test-Suite shelly-testsuite
 
   build-depends:
     shelly
-    , base                      >= 4.9 && < 5
-    , bytestring                >= 0.10
-    , directory                 >= 1.3.0.0 && < 1.4.0.0
+    , base
+    , bytestring
+    , directory
     , filepath
-    , hspec                     >= 2.0
-    , hspec-contrib
-    , HUnit                     >= 1.2
     , lifted-async
-    , mtl                       >= 2
-    , text                      >= 0.11
+    , mtl
+    , text
     , transformers
-    , unix-compat               < 0.6
+    , unix-compat
+    -- additional dependencies
+    , hspec                     >= 2.2.2
+    , hspec-contrib
+    , HUnit                     >= 1.2.5.2
 
   extensions:
     CPP

--- a/src/Shelly/Base.hs
+++ b/src/Shelly/Base.hs
@@ -9,9 +9,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE InstanceSigs#-}
--- | I started exposing multiple module (starting with one for finding)
--- Base prevented circular dependencies
--- However, Shelly went back to exposing a single module
+
 module Shelly.Base
   (
     Sh(..), ShIO, runSh, State(..), ReadOnlyState(..), StdHandle(..),
@@ -31,30 +29,24 @@ module Shelly.Base
     , addTrailingSlash
   ) where
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
-import Prelude hiding (FilePath, catch)
-#else
-import Prelude hiding (FilePath)
-#endif
-
 import Data.Text (Text)
-import System.Process( ProcessHandle, StdStream(..) )
+import System.Process( StdStream(..) )
 import System.IO ( Handle, hFlush, stderr, stdout )
 
-import Control.Monad (when, (>=>),
-         liftM
-       )
+import Control.Monad ( when, (>=>) )
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
+import Control.Applicative (Applicative, (<$>))
+import Data.Monoid (mappend)
+#endif
 import Control.Monad.Base
 import Control.Monad.Trans.Control
-import Control.Applicative (Applicative, (<$>))
 import System.Directory( doesDirectoryExist, listDirectory)
 import System.PosixCompat.Files( getSymbolicLinkStatus, isSymbolicLink )
-import System.FilePath  ( FilePath, isRelative)
+import System.FilePath  ( isRelative)
 import qualified System.FilePath as FP
 import qualified System.Directory as FS
 import Data.IORef (readIORef, modifyIORef, IORef)
-import Data.Monoid (mappend)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import Control.Exception (SomeException, catch, throwIO, Exception)

--- a/src/Shelly/Directory.hs
+++ b/src/Shelly/Directory.hs
@@ -2,7 +2,6 @@
 module Shelly.Directory where
 
 import System.IO.Error (modifyIOError, ioeSetLocation, ioeGetLocation)
-import qualified System.Directory as FP
 
 import qualified System.PosixCompat as Posix
 

--- a/test/examples/drain.hs
+++ b/test/examples/drain.hs
@@ -1,5 +1,5 @@
 {-# Language OverloadedStrings, ExtendedDefaultRules #-}
-import Prelude hiding (FilePath)
+
 import Shelly
 import Control.Monad (void)
 import Data.Text (Text)

--- a/test/src/CopySpec.hs
+++ b/test/src/CopySpec.hs
@@ -3,11 +3,6 @@ module CopySpec ( copySpec ) where
 
 import TestInit
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
-import Prelude hiding ( FilePath, catch)
-#else
-import Prelude hiding ( FilePath)
-#endif
 import Control.Monad (forM_)
 import System.IO.Error
 import Help

--- a/test/src/EnvSpec.hs
+++ b/test/src/EnvSpec.hs
@@ -2,11 +2,6 @@
 module EnvSpec ( envSpec ) where
 
 import TestInit
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
-import Prelude hiding ( FilePath, catch)
-#else
-import Prelude hiding ( FilePath)
-#endif
 import Data.Maybe
 
 envSpec :: Spec

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -6,7 +6,6 @@ import Data.Text (replace, pack, unpack)
 import System.Directory (createDirectoryIfMissing)
 import System.PosixCompat.Files (createSymbolicLink, fileExist)
 import qualified System.FilePath as SF
-import Shelly
 
 createSymlinkForTest :: IO ()
 createSymlinkForTest = do
@@ -105,7 +104,7 @@ findSpec = do
                     "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs", "SshSpec.hs",
                     "TestInit.hs", "TestMain.hs",
                     "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
-    
+
     unless isWindows $ before createSymlinkForTest $ do
       it "follow symlinks" $
          do res <-
@@ -134,4 +133,3 @@ findSpec = do
               , "symlinked_dir/hoge_file"
               , "zshrc"
               ]
-

--- a/test/src/Help.hs
+++ b/test/src/Help.hs
@@ -4,11 +4,6 @@ module Help (
 ) where
 
 import Shelly
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
-import Prelude hiding ( catch, FilePath )
-#else
-import Prelude hiding ( FilePath )
-#endif
 import Test.HUnit
 import Control.Monad.Trans ( MonadIO )
 

--- a/test/src/LogWithSpec.hs
+++ b/test/src/LogWithSpec.hs
@@ -2,7 +2,6 @@
 module LogWithSpec ( logWithSpec ) where
 
 import TestInit
-import Prelude hiding (FilePath)
 
 import Control.Concurrent (newEmptyMVar, takeMVar, putMVar)
 import Data.Text (Text)

--- a/test/src/ReadFileSpec.hs
+++ b/test/src/ReadFileSpec.hs
@@ -3,11 +3,6 @@
 module ReadFileSpec (readFileSpec) where
 
 import TestInit
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 706
-import Prelude hiding ( FilePath, catch)
-#else
-import Prelude hiding ( FilePath)
-#endif
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 
@@ -20,4 +15,3 @@ readFileSpec = describe "file with invalid encoding" $ do
     it "readfile" $ do
       res <- shelly $ readfile "test/data/zshrc"
       assert (T.length res > 0)
-

--- a/test/src/TestInit.hs
+++ b/test/src/TestInit.hs
@@ -9,5 +9,5 @@ import Shelly as Export
 #endif
 import Test.Hspec.Contrib.HUnit ()
 import System.Info(os)
-isWindows :: Bool 
+isWindows :: Bool
 isWindows = os == "mingw32"

--- a/test/src/WriteSpec.hs
+++ b/test/src/WriteSpec.hs
@@ -1,7 +1,6 @@
 module WriteSpec ( writeSpec ) where
 
 import TestInit
-import Prelude hiding (FilePath)
 
 import Data.Text (Text)
 default (Text)


### PR DESCRIPTION
Silence warnings for GHC 8.0 - 9.2; package lower bounds

- fix warnings except for deprecated `ListT`
- update lower bounds: only include GHC-8 buildable package versions
- remove obsolete `#if`s
- clean up `import` statements
- canonical Applicative/Monad definition of `Lifted.Sh`

Because this replaces the `ErrorT` instance by the `ExceptT` instance (following deprecation and pending removal of `ErrorT`), this should be released under a new major version (e.g. `1.10`).