### PR TITLE
Fix ShellCmd String arguments

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220620
+# version: 0.15.20221107
 #
-# REGENDATA ("0.15.20220620",["github","shelly.cabal"])
+# REGENDATA ("0.15.20221107",["github","shelly.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,11 +32,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.0.20220523
+          - compiler: ghc-9.4.1
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220523
+            compilerVersion: 9.4.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
+          - compiler: ghc-9.2.5
+            compilerKind: ghc
+            compilerVersion: 9.2.5
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.3
             compilerKind: ghc
             compilerVersion: 9.2.3
@@ -85,9 +90,8 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -95,7 +99,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -128,7 +132,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -157,18 +161,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -220,9 +212,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(shelly)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20221225
+# version: 0.15.20230128
 #
-# REGENDATA ("0.15.20221225",["github","shelly.cabal"])
+# REGENDATA ("0.15.20230128",["github","shelly.cabal"])
 #
 name: Haskell-CI
 on:
@@ -72,11 +72,6 @@ jobs:
             compilerVersion: 8.2.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -87,8 +82,9 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -96,7 +92,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -114,13 +111,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -203,8 +200,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_shelly}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package shelly" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package shelly" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(shelly)$/; }' >> cabal.project.local
@@ -214,8 +211,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v3
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -239,8 +236,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,15 @@
+# 1.12.0
+
+Cunning Defenstrator, 2023-01-29
+* Rework ShellCmd's instances to support String arguments.
+* Add some tests.
+* Remove the IncoherentInstances pragma as it's deprecated.
+* Bump the major version as CmdArg's method has changed.  Users must migrate
+  existing instances by replacing `toTextArg` with `toTextArgs` and wrapping the
+  old return value in a list.
+* Bump the resolver to lts-20.04 (the latest as of this writing).
+* Bump haskell-ci to 0.15.20230128
+
 # 1.11.0
 
 Andreas Abel, 2023-01-24

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,14 +1,14 @@
 # 1.12.0
 
-Cunning Defenstrator, 2023-01-29
-* Rework ShellCmd's instances to support String arguments.
+Cunning Defenstrator, 2023-02-12
+* Rework ShellCmd and ShellCommand instances to support String arguments.
 * Add some tests.
 * Remove the IncoherentInstances pragma as it's deprecated.
-* Bump the major version as CmdArg's method has changed.  Users must migrate
-  existing instances by replacing `toTextArg` with `toTextArgs` and wrapping the
-  old return value in a list.
-* Bump the resolver to lts-20.04 (the latest as of this writing).
-* Bump haskell-ci to 0.15.20230128
+* Bump the major version as CmdArg and ShellArg have changed.  Users must
+  migrate existing instances by replacing `toTextArg` with `toTextArgs` and
+  wrapping the old return value in a list.
+* Bump the resolver to lts-20.04.
+* Bump haskell-ci to 0.15.20230128.
 
 # 1.11.0
 

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,6 +1,6 @@
 Name:       shelly
 
-Version:     1.10.0
+Version:     2.0.0
 Synopsis:    shell-like (systems) programming in Haskell
 
 Description: Shelly provides convenient systems programming in Haskell,
@@ -31,6 +31,7 @@ Cabal-version:       >=1.10
 
 tested-with:
   GHC == 9.4.1
+  GHC == 9.2.5
   GHC == 9.2.3
   GHC == 9.0.2
   GHC == 8.10.7

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -123,6 +123,7 @@ Test-Suite shelly-testsuite
     Help
     LiftedSpec
     MoveSpec
+    PipeSpec
     ReadFileSpec
     RmSpec
     RunSpec

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,6 +1,6 @@
 Name:       shelly
 
-Version:     2.0.0
+Version:     1.12.0
 Synopsis:    shell-like (systems) programming in Haskell
 
 Description: Shelly provides convenient systems programming in Haskell,
@@ -38,7 +38,6 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
   GHC == 8.2.2
-  GHC == 8.0.2
 
 -- for the sdist of the test suite
 extra-source-files:

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -175,13 +175,18 @@ cmd fp args = run fp $ toTextArgs args
 -- | Argument converter for the variadic argument version of 'run' called 'cmd'.
 -- Useful for a type signature of a function that uses 'cmd'.
 class CmdArg a where toTextArgs :: a -> [Text]
-instance CmdArg Text   where toTextArgs = (: []) . id
-instance CmdArg String where toTextArgs = (: []) . T.pack
-instance {-# OVERLAPPABLE #-} CmdArg a
-  => CmdArg [a] where toTextArgs = concatMap toTextArgs
+
+instance CmdArg Text   where
+  toTextArgs = (: []) . id
+
+instance CmdArg String where
+  toTextArgs = (: []) . T.pack
+
+instance {-# OVERLAPPABLE #-} CmdArg a => CmdArg [a] where
+  toTextArgs = concatMap toTextArgs
 
 -- | For the variadic function 'cmd'.
---n
+--
 -- Partially applied variadic functions require type signatures.
 class ShellCmd t where
     cmdAll :: FilePath -> [Text] -> t

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -178,33 +177,29 @@ cmd fp args = run fp $ toTextArgs args
 
 -- | Argument converter for the variadic argument version of 'run' called 'cmd'.
 -- Useful for a type signature of a function that uses 'cmd'.
-class CmdArg a where toTextArg :: a -> Text
-instance CmdArg Text     where toTextArg = id
-instance CmdArg String   where toTextArg = T.pack
+class CmdArg a where toTextArgs :: a -> [Text]
+instance CmdArg Text   where toTextArgs = (: []) . id
+instance CmdArg String where toTextArgs = (: []) . T.pack
+instance {-# OVERLAPPABLE #-} CmdArg a
+  => CmdArg [a] where toTextArgs = concatMap toTextArgs
 
 -- | For the variadic function 'cmd'.
---
+--n
 -- Partially applied variadic functions require type signatures.
 class ShellCmd t where
     cmdAll :: FilePath -> [Text] -> t
 
+-- This is the only candidate for `_ <- cmd path x y z` so marking it incoherent will return it and
+-- terminate the search immediately.  This also removes the warning for do { cmd path x y z ; .. }
+-- as GHC will infer `Sh ()` instead of `Sh Text` as before.
+instance {-# INCOHERENT #-} s ~ () => ShellCmd (Sh s) where
+    cmdAll = run_
+
 instance ShellCmd (Sh Text) where
     cmdAll = run
 
-instance (s ~ Text, Show s) => ShellCmd (Sh s) where
-    cmdAll = run
-
--- note that Sh () actually doesn't work for its case (_<- cmd) when there is no type signature
-instance ShellCmd (Sh ()) where
-    cmdAll = run_
-
 instance (CmdArg arg, ShellCmd result) => ShellCmd (arg -> result) where
-    cmdAll fp acc x = cmdAll fp (acc ++ [toTextArg x])
-
-instance (CmdArg arg, ShellCmd result) => ShellCmd ([arg] -> result) where
-    cmdAll fp acc x = cmdAll fp (acc ++ map toTextArg x)
-
-
+    cmdAll fp acc x = cmdAll fp (acc ++ toTextArgs x)
 
 -- | Variadic argument version of 'run'.
 -- Please see the documenation for 'run'.

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
 - '.'
 - shelly-extra/
-resolver: lts-18.16
+resolver: lts-20.04
 extra-deps: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 586286
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/16.yaml
-    sha256: cdead65fca0323144b346c94286186f4969bf85594d649c49c7557295675d8a5
-  original: lts-18.16
+    sha256: 3770dfd79f5aed67acdcc65c4e7730adddffe6dba79ea723cfb0918356fc0f94
+    size: 648660
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/4.yaml
+  original: lts-20.4

--- a/test/data/dir/symlinked_dir
+++ b/test/data/dir/symlinked_dir
@@ -1,0 +1,1 @@
+../symlinked_dir

--- a/test/data/dir/symlinked_dir
+++ b/test/data/dir/symlinked_dir
@@ -1,1 +1,0 @@
-../symlinked_dir

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -51,7 +51,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> ls "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -59,7 +59,7 @@ findSpec = do
       res <- shelly $ cd "test" >> ls "src"
       sort res @?=  map toWindowsStyleIfNecessary ["src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs",
                     "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs", "src/LogWithSpec.hs", "src/MoveSpec.hs",
-                    "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/SshSpec.hs",
+                    "src/PipeSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/SshSpec.hs",
                     "src/TestInit.hs", "src/TestMain.hs",
                     "src/WhichSpec.hs", "src/WriteSpec.hs", "src/sleep.hs"]
 
@@ -67,7 +67,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> find "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -86,13 +86,13 @@ findSpec = do
       if isWindows
         then sort res @?= ["test/src\\CopySpec.hs", "test/src\\EnvSpec.hs", "test/src\\FailureSpec.hs",
                     "test/src\\FindSpec.hs", "test/src\\Help.hs", "test/src\\LiftedSpec.hs",
-                    "test/src\\LogWithSpec.hs", "test/src\\MoveSpec.hs", "test/src\\ReadFileSpec.hs",
+                    "test/src\\LogWithSpec.hs", "test/src\\MoveSpec.hs", "test/src\\PipeSpec.hs", "test/src\\ReadFileSpec.hs",
                     "test/src\\RmSpec.hs", "test/src\\RunSpec.hs", "test/src\\SshSpec.hs",
                     "test/src\\TestInit.hs", "test/src\\TestMain.hs", "test/src\\WhichSpec.hs", "test/src\\WriteSpec.hs",
                     "test/src\\sleep.hs"]
         else sort res @?= ["test/src/CopySpec.hs", "test/src/EnvSpec.hs", "test/src/FailureSpec.hs",
                     "test/src/FindSpec.hs", "test/src/Help.hs", "test/src/LiftedSpec.hs",
-                    "test/src/LogWithSpec.hs", "test/src/MoveSpec.hs", "test/src/ReadFileSpec.hs",
+                    "test/src/LogWithSpec.hs", "test/src/MoveSpec.hs", "test/src/PipeSpec.hs", "test/src/ReadFileSpec.hs",
                     "test/src/RmSpec.hs", "test/src/RunSpec.hs", "test/src/SshSpec.hs",
                     "test/src/TestInit.hs", "test/src/TestMain.hs", "test/src/WhichSpec.hs", "test/src/WriteSpec.hs",
                     "test/src/sleep.hs"]
@@ -101,8 +101,8 @@ findSpec = do
       res <- shelly $ relPath "test/src" >>= find >>= mapM (relativeTo "test/src")
       sort res @?= ["CopySpec.hs", "EnvSpec.hs", "FailureSpec.hs", "FindSpec.hs",
                     "Help.hs", "LiftedSpec.hs", "LogWithSpec.hs", "MoveSpec.hs",
-                    "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs", "SshSpec.hs",
-                    "TestInit.hs", "TestMain.hs",
+                    "PipeSpec.hs", "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs",
+                    "SshSpec.hs", "TestInit.hs", "TestMain.hs",
                     "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
 
     unless isWindows $ before createSymlinkForTest $ do

--- a/test/src/PipeSpec.hs
+++ b/test/src/PipeSpec.hs
@@ -1,0 +1,97 @@
+module PipeSpec ( pipeSpec ) where
+
+import TestInit
+
+import Data.Text (Text)
+import qualified Shelly.Pipe as P
+
+pipeSpec :: Spec
+pipeSpec = do
+  describe "P.cmd" $ do
+    let shouldBeTxt res t = res @?= [t :: Text]
+
+    it "with Text" $ do
+      res <- P.shelly $ P.cmd "echo" ("wibble" :: Text)
+      res `shouldBeTxt` "wibble\n"
+
+    it "with String" $ do
+      res <- P.shelly $ P.cmd "echo" "wibble"
+      res `shouldBeTxt` "wibble\n"
+
+    it "with [Text]" $ do
+      res <- P.shelly $ P.cmd "echo" (["wibble"] :: [Text])
+      res `shouldBeTxt` "wibble\n"
+
+    it "with [String]" $ do
+      res <- P.shelly $ P.cmd "echo" ["wibble"]
+      res `shouldBeTxt` "wibble\n"
+
+    -- Check all two argument permutations (with replacement) of { Text, String, [Text], [String] }.
+    it "with Text and Text" $ do
+      res <- P.shelly $ P.cmd "echo" ("wibble" :: Text) ("wobble" :: Text)
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with Text and String" $ do
+      res <- P.shelly $ P.cmd "echo" ("wibble" :: Text) "wobble"
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with Text and [Text]" $ do
+      res <- P.shelly $ P.cmd "echo" ("wibble" :: Text) (["wobble", "wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with Text and [String]" $ do
+      res <- P.shelly $ P.cmd "echo" ("wibble" :: Text) ["wobble", "wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with String and Text" $ do
+      res <- P.shelly $ P.cmd "echo" "wibble" ("wobble" :: Text)
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with String and String" $ do
+      res <- P.shelly $ P.cmd "echo" "wibble" "wobble"
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with String and [Text]" $ do
+      res <- P.shelly $ P.cmd "echo" "wibble" (["wobble", "wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and Text" $ do
+      res <- P.shelly $ P.cmd "echo" (["wibble", "wobble"] :: [Text]) ("wurble" :: Text)
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and String" $ do
+      res <- P.shelly $ P.cmd "echo" (["wibble", "wobble"] :: [Text]) "wurble"
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and [Text]" $ do
+      res <- P.shelly $ P.cmd "echo" (["wibble", "wobble"] :: [Text]) (["wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and [String]" $ do
+      res <- P.shelly $ P.cmd "echo" (["wibble", "wobble"] :: [Text]) ["wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and Text " $ do
+      res <- P.shelly $ P.cmd "echo" ["wibble", "wobble"] ("wurble" :: Text)
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and String " $ do
+      res <- P.shelly $ P.cmd "echo" ["wibble", "wobble"] "wurble"
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and [Text] " $ do
+      res <- P.shelly $ P.cmd "echo" ["wibble", "wobble"] (["wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and [String] " $ do
+      res <- P.shelly $ P.cmd "echo" ["wibble", "wobble"] ["wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    -- Check unit cases
+    it "returns [()]" $ do
+      res <- P.shelly $ P.cmd "echo" "wibble" "wobble"
+      res @?= [()]
+
+    it "works with underscore" $ do
+      _ <- P.shelly $ P.cmd "echo" "wibble" "wobble"
+      True `shouldBe` True

--- a/test/src/RunSpec.hs
+++ b/test/src/RunSpec.hs
@@ -3,6 +3,7 @@ module RunSpec ( runSpec ) where
 import TestInit
 
 import qualified Data.Text as T
+import Data.Text (Text)
 import System.IO
 
 runSpec :: Spec
@@ -28,6 +29,100 @@ runSpec = do
       if isWindows
         then res @?= "Selbstverst\228ndlich \252berraschend\r\n"
         else res @?= "Selbstverst\228ndlich \252berraschend\n"
+
+  describe "cmd" $ do
+    let shouldBeTxt res t = res @?= (t :: Text)
+
+    it "with Text" $ do
+      res <- shelly $ cmd "echo" ("wibble" :: Text)
+      res `shouldBeTxt` "wibble\n"
+
+    it "with String" $ do
+      res <- shelly $ cmd "echo" "wibble"
+      res `shouldBeTxt` "wibble\n"
+
+    it "with [Text]" $ do
+      res <- shelly $ cmd "echo" (["wibble"] :: [Text])
+      res `shouldBeTxt` "wibble\n"
+
+    it "with [String]" $ do
+      res <- shelly $ cmd "echo" ["wibble"]
+      res `shouldBeTxt` "wibble\n"
+
+    -- Check all two argument permutations (with replacement) of { Text, String, [Text], [String] }.
+    it "with Text and Text" $ do
+      res <- shelly $ cmd "echo" ("wibble" :: Text) ("wobble" :: Text)
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with Text and String" $ do
+      res <- shelly $ cmd "echo" ("wibble" :: Text) "wobble"
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with Text and [Text]" $ do
+      res <- shelly $ cmd "echo" ("wibble" :: Text) (["wobble", "wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with Text and [String]" $ do
+      res <- shelly $ cmd "echo" ("wibble" :: Text) ["wobble", "wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with String and Text" $ do
+      res <- shelly $ cmd "echo" "wibble" ("wobble" :: Text)
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with String and String" $ do
+      res <- shelly $ cmd "echo" "wibble" "wobble"
+      res `shouldBeTxt` "wibble wobble\n"
+
+    it "with String and [Text]" $ do
+      res <- shelly $ cmd "echo" "wibble" (["wobble", "wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and Text" $ do
+      res <- shelly $ cmd "echo" (["wibble", "wobble"] :: [Text]) ("wurble" :: Text)
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and String" $ do
+      res <- shelly $ cmd "echo" (["wibble", "wobble"] :: [Text]) "wurble"
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and [Text]" $ do
+      res <- shelly $ cmd "echo" (["wibble", "wobble"] :: [Text]) (["wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [Text] and [String]" $ do
+      res <- shelly $ cmd "echo" (["wibble", "wobble"] :: [Text]) ["wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and Text " $ do
+      res <- shelly $ cmd "echo" ["wibble", "wobble"] ("wurble" :: Text)
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and String " $ do
+      res <- shelly $ cmd "echo" ["wibble", "wobble"] "wurble"
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and [Text] " $ do
+      res <- shelly $ cmd "echo" ["wibble", "wobble"] (["wurble"] :: [Text])
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    it "with [String] and [String] " $ do
+      res <- shelly $ cmd "echo" ["wibble", "wobble"] ["wurble"]
+      res `shouldBeTxt` "wibble wobble wurble\n"
+
+    -- Check unit cases
+    it "returns Unit" $ do
+      res <- shelly $ cmd "echo" "wibble" "wobble"
+      res @?= ()
+
+    it "defaults to Unit" $ do
+      _ <- shelly $ cmd "echo" "wibble" "wobble"
+      True `shouldBe` True
+
+    -- This should now compile without a warning since ghc should infer Sh () instead of Sh Text.
+    it "defaults to Unit without underscore" $ do
+      shelly $ cmd "echo" "wibble" "wobble"
+      True `shouldBe` True
 
   -- Bash-related commands
   describe "bash" $ do

--- a/test/src/RunSpec.hs
+++ b/test/src/RunSpec.hs
@@ -121,12 +121,12 @@ runSpec = do
       res <- shelly $ cmd "echo" "wibble" "wobble"
       res @?= ()
 
-    it "defaults to Unit" $ do
+    it "works with underscore" $ do
       _ <- shelly $ cmd "echo" "wibble" "wobble"
       True `shouldBe` True
 
     -- This should now compile without a warning since ghc should infer Sh () instead of Sh Text.
-    it "defaults to Unit without underscore" $ do
+    it "defaults to Unit" $ do
       shelly $ cmd "echo" "wibble" "wobble"
       True `shouldBe` True
 

--- a/test/src/TestMain.hs
+++ b/test/src/TestMain.hs
@@ -13,6 +13,7 @@ import CopySpec
 import LiftedSpec
 import RunSpec
 import SshSpec
+import PipeSpec
 
 import Test.Hspec
 
@@ -30,3 +31,4 @@ main = hspec $ do
     liftedSpec
     runSpec
     sshSpec
+    pipeSpec


### PR DESCRIPTION
Fixes #143.

Changelog:
- Rework ShellCmd's instances to support String arguments.
- Add some tests.
- Remove the IncoherentInstances pragma as it's deprecated.
- Bump the major version as CmdArg's method has changed.
- Bump the resolver to lts-20.04 (the latest as of this writing).
- Bump haskell-ci to 0.15.20221107