### PR TITLE
Release v1.12.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230128
+# version: 0.15.20230217
 #
-# REGENDATA ("0.15.20230128",["github","shelly.cabal"])
+# REGENDATA ("0.15.20230217",["github","shelly.cabal"])
 #
 name: Haskell-CI
 on:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,14 +1,28 @@
 # 1.12.0
 
-Cunning Defenstrator, 2023-02-12
-* Rework ShellCmd and ShellCommand instances to support String arguments.
-* Add some tests.
-* Remove the IncoherentInstances pragma as it's deprecated.
-* Bump the major version as CmdArg and ShellArg have changed.  Users must
-  migrate existing instances by replacing `toTextArg` with `toTextArgs` and
-  wrapping the old return value in a list.
-* Bump the resolver to lts-20.04.
-* Bump haskell-ci to 0.15.20230128.
+Andreas Abel, 2023-02-27
+* Rework `ShellCmd` and `ShellCommand` instances to support `String` arguments:
+  Issue [#143](https://github.com/gregwebs/Shelly.hs/issues/143)
+  fixed by Cunning Defenstrator in
+  PR [#221](https://github.com/gregwebs/Shelly.hs/pull/221).
+
+  This involves a **breaking change** in classes `CmdArg` and `ShellArg`:
+  Method `toTextArg` has been replaced by `toTextArgs`.
+
+  Sample migration:
+  ```haskell
+  #if MIN_VERSION_shelly(1,12,0)
+  -- new
+  import Shelly (toTextArgs)
+  snoc opts arg = opts ++ toTextArgs arg
+  #else
+  -- old
+  import Shelly (toTextArg)
+  snoc opts arg = opts ++ [ toTextArg arg ]
+  #endif
+  ```
+* Dropped GHC 8.0 to get rid of deprecated `LANGUAGE IncoherentInstances`.
+* Builds with GHC 8.2 - 9.6.
 
 # 1.11.0
 

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,33 +1,33 @@
-Name:       shelly
+cabal-version: 2.0
 
-Version:     1.12.0
-Synopsis:    shell-like (systems) programming in Haskell
+Name:          shelly
+Version:       1.12.0
 
-Description: Shelly provides convenient systems programming in Haskell,
-             similar in spirit to POSIX shells. Shelly:
-             .
-               * is aimed at convenience and getting things done rather than
-                 being a demonstration of elegance,
-             .
-               * has detailed and useful error messages,
-             .
-               * maintains its own environment, making it thread-safe.
-             .
-             Shelly is originally forked from the Shellish package.
-             .
-             See the shelly-extra package for additional functionality.
-             .
-             An overview is available in the README: <https://github.com/gregwebs/Shelly.hs/blob/master/README.md>
+Synopsis:      shell-like (systems) programming in Haskell
 
+Description:   Shelly provides convenient systems programming in Haskell,
+               similar in spirit to POSIX shells. Shelly:
+               .
+                 * is aimed at convenience and getting things done rather than
+                   being a demonstration of elegance,
+               .
+                 * has detailed and useful error messages,
+               .
+                 * maintains its own environment, making it thread-safe.
+               .
+               Shelly is originally forked from the Shellish package.
+               .
+               See the shelly-extra package for additional functionality.
+               .
+               An overview is available in the README: <https://github.com/gregwebs/Shelly.hs/blob/master/README.md>
 
-Homepage:            https://github.com/gregwebs/Shelly.hs
-License:             BSD3
-License-file:        LICENSE
-Author:              Greg Weber, Petr Rockai
-Maintainer:          Andreas Abel
-Category:            Development
-Build-type:          Simple
-Cabal-version:       >=1.10
+Homepage:      https://github.com/gregwebs/Shelly.hs
+License:       BSD3
+License-file:  LICENSE
+Author:        Greg Weber, Petr Rockai
+Maintainer:    Andreas Abel
+Category:      Development
+Build-type:    Simple
 
 tested-with:
   GHC == 9.4.4
@@ -39,6 +39,10 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
 
+extra-doc-files:
+  README.md
+  ChangeLog.md
+
 -- for the sdist of the test suite
 extra-source-files:
   test/src/*.hs
@@ -49,8 +53,6 @@ extra-source-files:
   test/data/symlinked_dir/hoge_file
   test/data/hello.sh
   test/testall
-  README.md
-  ChangeLog.md
 
 Library
   Exposed-modules:
@@ -66,30 +68,34 @@ Library
 
   hs-source-dirs: src
 
-  -- Andreas Abel, 2021-11-20:
-  -- Unless other constraints exist, lower bounds are chosen
-  -- such that all versions that build with GHC 8
-  -- (according to matrix.hackage.haskell.org) are included.
+  -- Andreas Abel, 2021-11-20, 2023-02-27:
+  -- Unless other constraints exist, lower bounds (lb) are chosen
+  -- as suggested by `cabal gen-bounds` with GHC 8.2, with some fixes:
+  --   * lb version should exist on hackage
+  --   * need to respect the ghc-shipped version (e.g. containers).
+  -- Upper bounds should be omitted in general,
+  -- unless breakage with major version bumps is expected.
+  -- Upper bounds can always be added after the fact via (bulk) hackage revisions.
   Build-depends:
-      base                      >= 4.9       && < 5
-        -- support GHC >= 8
-    , async
-    , bytestring                >= 0.10.6.0
-    , containers                >= 0.5.7.0
+      base                      >= 4.10      && < 5
+        -- support GHC >= 8.2
+    , async                     >= 2.2.3
+    , bytestring                >= 0.10.8.0
+    , containers                >= 0.5.10.2
     , directory                 >= 1.3.0.0   && < 1.4
-    , enclosed-exceptions
-    , exceptions                >= 0.8.2.1
-    , filepath
-    , lifted-async
+    , enclosed-exceptions       >= 1.0.1
+    , exceptions                >= 0.10.0
+    , filepath                  >= 1.4.1.1
+    , lifted-async              >= 0.10.2
     , lifted-base               >= 0.2.3.2
     , monad-control             >= 0.3.2     && < 1.1
     , mtl                       >= 2.2.2
-    , process                   >= 1.4
-    , text                      >= 1.2.2.0
+    , process                   >= 1.6.1.0
+    , text                      >= 1.2.3.1
     , time                      >= 1.3       && < 1.13
-    , transformers              >= 0.5.0.0
-    , transformers-base
-    , unix-compat               >= 0.4.1.1   && < 0.7
+    , transformers              >= 0.5.2.0
+    , transformers-base         >= 0.4.5
+    , unix-compat               >= 0.4.1.1   && < 0.8
 
   ghc-options:
     -Wall

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -149,35 +149,14 @@ import System.Process
   , ProcessHandle, StdStream(..)
   )
 
-{- GHC won't default to Text with this, even with extensions!
- - see: http://hackage.haskell.org/trac/ghc/ticket/6030
-class CmdArgs a where
-  toTextArgs :: a -> [Text]
-
-instance CmdArgs Text       where toTextArgs t = [t]
-instance CmdArgs FilePath   where toTextArgs t = [toTextIgnore t]
-instance CmdArgs [Text]     where toTextArgs = id
-instance CmdArgs [FilePath] where toTextArgs = map toTextIgnore
-
-instance CmdArgs (Text, Text) where
-  toTextArgs (t1,t2) = [t1, t2]
-instance CmdArgs (FilePath, FilePath) where
-  toTextArgs (fp1,fp2) = [toTextIgnore fp1, toTextIgnore fp2]
-instance CmdArgs (Text, FilePath) where
-  toTextArgs (t1, fp1) = [t1, toTextIgnore fp1]
-instance CmdArgs (FilePath, Text) where
-  toTextArgs (fp1,t1) = [toTextIgnore fp1, t1]
-
-cmd :: (CmdArgs args) => FilePath -> args -> Sh Text
-cmd fp args = run fp $ toTextArgs args
--}
-
 -- | Argument converter for the variadic argument version of 'run' called 'cmd'.
 -- Useful for a type signature of a function that uses 'cmd'.
-class CmdArg a where toTextArgs :: a -> [Text]
+class CmdArg a where
+  -- | @since 1.12.0
+  toTextArgs :: a -> [Text]
 
 instance CmdArg Text   where
-  toTextArgs = (: []) . id
+  toTextArgs = (: [])
 
 instance CmdArg String where
   toTextArgs = (: []) . T.pack

--- a/src/Shelly/Pipe.hs
+++ b/src/Shelly/Pipe.hs
@@ -610,9 +610,16 @@ put = sh1 S.put
 -- polyvariadic vodoo
 
 -- | Converter for the variadic argument version of 'run' called 'cmd'.
-class ShellArg a where toTextArgs :: a -> [Text]
-instance ShellArg Text where toTextArgs = (: []) . id
-instance ShellArg String where toTextArgs = (: []) . T.pack
+class ShellArg a where
+  -- | @since 1.12.0
+  toTextArgs :: a -> [Text]
+
+instance ShellArg Text where
+  toTextArgs = (: [])
+
+instance ShellArg String where
+  toTextArgs = (: []) . T.pack
+
 instance {-# OVERLAPPABLE #-} ShellArg a => ShellArg [a] where
   toTextArgs = Prelude.concatMap toTextArgs
 

--- a/test/examples/color.hs
+++ b/test/examples/color.hs
@@ -8,5 +8,5 @@ import Data.Text (Text)
 default (Text)
 
 main = shelly $ do
-  void $ liftIO $ rawSystem "ls" ["--color=auto", "../dist"]
-  run_ "ls" ["--color=auto", "../dist"]
+  void $ liftIO $ rawSystem "ls" ["--color=auto", "test"]
+  run_ "ls" ["--color=auto", "test"]

--- a/test/examples/drain.hs
+++ b/test/examples/drain.hs
@@ -8,7 +8,7 @@ default (Text)
 
 main :: IO ()
 main = do
-  let exDir = "./examples"
+  let exDir = "./test/examples"
   void $ shelly $ do
     let strs = ["a", "b"] :: [String]
     let texts = ["a", "b"] :: [Text]

--- a/test/examples/run-handles.hs
+++ b/test/examples/run-handles.hs
@@ -3,6 +3,6 @@ import Shelly
 -- This test runs, but causes this error to show up:
 -- Exception: cannot access an inherited pipe
 main = shelly $
-  runHandles "bash" ["examples/test.sh"] handles doNothing
+  runHandles "bash" ["test/examples/test.sh"] handles doNothing
   where handles = [InHandle Inherit, OutHandle Inherit, ErrorHandle Inherit]
         doNothing _ _ _ = return ""


### PR DESCRIPTION
- Drop GHC 8.2, bump lower bounds of dependencies accordingly
- Tested with GHC 8.2 -9.6.1 alpha3 (with unreleased `unix-compat-0.7`).

Candidate at: https://hackage.haskell.org/package/shelly-1.12.0/candidate