### PR TITLE
Customize the command printing function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+# 1.12.1
+
+Andreas Abel, 2023-04-03
+* Add `print_commands_with` and `echoWith` which can be used to override
+  the default printing functions (e.g. to add color).
+  (Chris Wendt, PR [#228](https://github.com/gregwebs/Shelly.hs/pull/228).)
+* Tested with GHC 8.2 - 9.6 (cabal) and GHC 8.10 - 9.6 (stack).
+
 # 1.12.0.1
 
 Andreas Abel, 2023-04-02

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 Name:          shelly
-Version:       1.12.0.1
+Version:       1.12.1
 
 Synopsis:      shell-like (systems) programming in Haskell
 

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -131,6 +131,7 @@ Test-Suite shelly-testsuite
     LiftedSpec
     MoveSpec
     PipeSpec
+    PrintCommandsFnSpec
     ReadFileSpec
     RmSpec
     RunSpec

--- a/src/Shelly/Base.hs
+++ b/src/Shelly/Base.hs
@@ -20,7 +20,7 @@ module Shelly.Base
     unpack, gets, get, modify, trace,
     ls, lsRelAbs,
     toTextIgnore,
-    echo, echo_n, echo_err, echo_n_err, inspect, inspect_err,
+    echo, echo_n, echo_err, echo_n_err, echoWith, inspect, inspect_err,
     catchany,
     liftIO, (>=>),
     eitherRelativeTo, relativeTo, maybeRelativeTo,
@@ -105,6 +105,7 @@ data State = State
    , sPutStderr :: Text -> IO ()   -- ^ by default, hPutStrLn stderr
    , sPrintStderr :: Bool   -- ^ print stderr of command that is executed
    , sPrintCommands :: Bool -- ^ print command that is executed
+   , sPrintCommandsFn :: Text -> IO () -- ^ how to print commands, default is hputStrLn stdout
    , sInitCommandHandles :: StdInit -- ^ initializers for the standard process handles
                                     -- when running a command
    , sCommandEscaping :: Bool -- ^ when running a command, escape shell characters such as '*' rather
@@ -305,6 +306,10 @@ echo       msg = traceEcho msg >> liftIO (TIO.putStrLn msg >> hFlush stdout)
 echo_n     msg = traceEcho msg >> liftIO (TIO.putStr msg >> hFlush stdout)
 echo_err   msg = traceEcho msg >> liftIO (TIO.hPutStrLn stderr msg >> hFlush stdout)
 echo_n_err msg = traceEcho msg >> liftIO (TIO.hPutStr stderr msg >> hFlush stderr)
+
+-- | @since 1.12.1
+echoWith :: (Text -> IO ()) -> Text -> Sh ()
+echoWith f msg = traceEcho msg >> liftIO (f msg >> hFlush stdout)
 
 traceEcho :: Text -> Sh ()
 traceEcho msg = trace ("echo " `mappend` "'" `mappend` msg `mappend` "'")

--- a/src/Shelly/Lifted.hs
+++ b/src/Shelly/Lifted.hs
@@ -34,7 +34,7 @@ module Shelly.Lifted
 
          -- * Entering Sh
          Sh, ShIO, S.shelly, S.shellyNoDir, S.shellyFailDir, sub
-         , silently, verbosely, escaping, print_stdout, print_stderr, print_commands
+         , silently, verbosely, escaping, print_stdout, print_stderr, print_commands, print_commands_with
          , tracing, errExit
          , log_stdout_with, log_stderr_with
 
@@ -57,7 +57,7 @@ module Shelly.Lifted
          , cd, chdir, chdir_p, pwd
 
          -- * Printing
-         , echo, echo_n, echo_err, echo_n_err, inspect, inspect_err
+         , echo, echo_n, echo_err, echo_n_err, echoWith, inspect, inspect_err
          , tag, trace, S.show_command
 
          -- * Querying filesystem
@@ -324,6 +324,10 @@ print_stderr shouldPrint a = controlSh $ \runInSh -> S.print_stderr shouldPrint 
 print_commands :: MonadShControl m => Bool -> m a -> m a
 print_commands shouldPrint a = controlSh $ \runInSh -> S.print_commands shouldPrint (runInSh a)
 
+-- | @since 1.12.1
+print_commands_with :: MonadShControl m => (Text -> IO ()) -> m a -> m a
+print_commands_with fn a = controlSh $ \runInSh -> S.print_commands_with fn (runInSh a)
+
 sub :: MonadShControl m => m a -> m a
 sub a = controlSh $ \runInSh -> S.sub (runInSh a)
 
@@ -553,6 +557,10 @@ echo       = liftSh . S.echo
 echo_n     = liftSh . S.echo_n
 echo_err   = liftSh . S.echo_err
 echo_n_err = liftSh . S.echo_n_err
+
+-- | @since 1.12.1
+echoWith :: MonadSh m => (Text -> IO ()) -> Text -> m ()
+echoWith f msg = liftSh $ S.echoWith f msg
 
 relPath :: MonadSh m => FilePath -> m FilePath
 relPath = liftSh . S.relPath

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -51,7 +51,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> ls "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./PrintCommandsFnSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -59,7 +59,7 @@ findSpec = do
       res <- shelly $ cd "test" >> ls "src"
       sort res @?=  map toWindowsStyleIfNecessary ["src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs",
                     "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs", "src/LogWithSpec.hs", "src/MoveSpec.hs",
-                    "src/PipeSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/ShowCommandSpec.hs", "src/SshSpec.hs",
+                    "src/PipeSpec.hs", "src/PrintCommandsFnSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/ShowCommandSpec.hs", "src/SshSpec.hs",
                     "src/TestInit.hs", "src/TestMain.hs",
                     "src/WhichSpec.hs", "src/WriteSpec.hs", "src/sleep.hs"]
 
@@ -67,7 +67,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> find "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./PrintCommandsFnSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -86,13 +86,13 @@ findSpec = do
       if isWindows
         then sort res @?= ["test/src\\CopySpec.hs", "test/src\\EnvSpec.hs", "test/src\\FailureSpec.hs",
                     "test/src\\FindSpec.hs", "test/src\\Help.hs", "test/src\\LiftedSpec.hs",
-                    "test/src\\LogWithSpec.hs", "test/src\\MoveSpec.hs", "test/src\\PipeSpec.hs", "test/src\\ReadFileSpec.hs",
+                    "test/src\\LogWithSpec.hs", "test/src\\MoveSpec.hs", "test/src\\PipeSpec.hs", "test/src\\PrintCommandsFnSpec.hs", "test/src\\ReadFileSpec.hs",
                     "test/src\\RmSpec.hs", "test/src\\RunSpec.hs", "test/src\\ShowCommandSpec.hs", "test/src\\SshSpec.hs",
                     "test/src\\TestInit.hs", "test/src\\TestMain.hs", "test/src\\WhichSpec.hs", "test/src\\WriteSpec.hs",
                     "test/src\\sleep.hs"]
         else sort res @?= ["test/src/CopySpec.hs", "test/src/EnvSpec.hs", "test/src/FailureSpec.hs",
                     "test/src/FindSpec.hs", "test/src/Help.hs", "test/src/LiftedSpec.hs",
-                    "test/src/LogWithSpec.hs", "test/src/MoveSpec.hs", "test/src/PipeSpec.hs", "test/src/ReadFileSpec.hs",
+                    "test/src/LogWithSpec.hs", "test/src/MoveSpec.hs", "test/src/PipeSpec.hs", "test/src/PrintCommandsFnSpec.hs", "test/src/ReadFileSpec.hs",
                     "test/src/RmSpec.hs", "test/src/RunSpec.hs", "test/src/ShowCommandSpec.hs", "test/src/SshSpec.hs",
                     "test/src/TestInit.hs", "test/src/TestMain.hs", "test/src/WhichSpec.hs", "test/src/WriteSpec.hs",
                     "test/src/sleep.hs"]
@@ -101,7 +101,7 @@ findSpec = do
       res <- shelly $ relPath "test/src" >>= find >>= mapM (relativeTo "test/src")
       sort res @?= ["CopySpec.hs", "EnvSpec.hs", "FailureSpec.hs", "FindSpec.hs",
                     "Help.hs", "LiftedSpec.hs", "LogWithSpec.hs", "MoveSpec.hs",
-                    "PipeSpec.hs", "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs",
+                    "PipeSpec.hs", "PrintCommandsFnSpec.hs", "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs",
                     "ShowCommandSpec.hs", "SshSpec.hs", "TestInit.hs", "TestMain.hs",
                     "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
 

--- a/test/src/PrintCommandsFnSpec.hs
+++ b/test/src/PrintCommandsFnSpec.hs
@@ -1,0 +1,14 @@
+module PrintCommandsFnSpec (printCommandsFnSpec) where
+
+import TestInit
+import Data.IORef
+
+printCommandsFnSpec :: Spec
+printCommandsFnSpec = do
+    describe "sPrintCommandsFn" $ do
+      it "calls the custom print function" $ do
+        calledRef <- newIORef False
+        let printFn = \_ -> writeIORef calledRef True
+        _ <- shelly $ print_commands True $ print_commands_with printFn $ run "echo" []
+        called <- readIORef calledRef
+        called @?= True

--- a/test/src/TestMain.hs
+++ b/test/src/TestMain.hs
@@ -7,6 +7,7 @@ import WriteSpec
 import MoveSpec
 import RmSpec
 import FindSpec
+import PrintCommandsFnSpec
 import EnvSpec
 import FailureSpec
 import CopySpec
@@ -26,6 +27,7 @@ main = hspec $ do
     moveSpec
     rmSpec
     findSpec
+    printCommandsFnSpec
     envSpec
     failureSpec
     copySpec


### PR DESCRIPTION
Useful for adding color or a prefix like `"Running command: " <> cmd <> " ..."`.