### PR TITLE
More robust show_command

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230217
+# version: 0.15.20230321
 #
-# REGENDATA ("0.15.20230217",["github","shelly.cabal"])
+# REGENDATA ("0.15.20230321",["github","shelly.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,14 +32,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.1
+            compilerKind: ghc
+            compilerVersion: 9.6.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.5
+          - compiler: ghc-9.2.7
             compilerKind: ghc
-            compilerVersion: 9.2.5
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -80,20 +85,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -111,13 +114,13 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')

--- a/.github/workflows/mac-win-ci.yml
+++ b/.github/workflows/mac-win-ci.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ghc:
-          - 8.8.4
           - 8.10.7
           - 9.0.2
           - 9.2.5
           - 9.4.4
+          - 9.6.1
       fail-fast: false
 
     # 2021-11-14

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+# 1.12.0.1
+
+Andreas Abel, 2023-04-02
+* Make `show_command` more robust to special characters
+  and only quote when necessary.
+  (Chris Wendt, PR [#229](https://github.com/gregwebs/Shelly.hs/pull/229).)
+* Tested with GHC 8.2 - 9.6 (cabal) and GHC 8.10 - 9.6 (stack).
+
 # 1.12.0
 
 Andreas Abel, 2023-02-27

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -30,8 +30,9 @@ Category:      Development
 Build-type:    Simple
 
 tested-with:
+  GHC == 9.6.1
   GHC == 9.4.4
-  GHC == 9.2.5
+  GHC == 9.2.7
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -133,6 +133,7 @@ Test-Suite shelly-testsuite
     ReadFileSpec
     RmSpec
     RunSpec
+    ShowCommandSpec
     SshSpec
     TestInit
     WhichSpec

--- a/shelly.cabal
+++ b/shelly.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.0
 
 Name:          shelly
-Version:       1.12.0
+Version:       1.12.0.1
 
 Synopsis:      shell-like (systems) programming in Haskell
 

--- a/test/src/FindSpec.hs
+++ b/test/src/FindSpec.hs
@@ -51,7 +51,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> ls "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -59,7 +59,7 @@ findSpec = do
       res <- shelly $ cd "test" >> ls "src"
       sort res @?=  map toWindowsStyleIfNecessary ["src/CopySpec.hs", "src/EnvSpec.hs", "src/FailureSpec.hs",
                     "src/FindSpec.hs", "src/Help.hs", "src/LiftedSpec.hs", "src/LogWithSpec.hs", "src/MoveSpec.hs",
-                    "src/PipeSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/SshSpec.hs",
+                    "src/PipeSpec.hs", "src/ReadFileSpec.hs", "src/RmSpec.hs", "src/RunSpec.hs", "src/ShowCommandSpec.hs", "src/SshSpec.hs",
                     "src/TestInit.hs", "src/TestMain.hs",
                     "src/WhichSpec.hs", "src/WriteSpec.hs", "src/sleep.hs"]
 
@@ -67,7 +67,7 @@ findSpec = do
       res <- shelly $ cd "test/src" >> find "."
       sort res @?= map toWindowsStyleIfNecessary ["./CopySpec.hs", "./EnvSpec.hs", "./FailureSpec.hs",
                     "./FindSpec.hs", "./Help.hs", "./LiftedSpec.hs", "./LogWithSpec.hs", "./MoveSpec.hs",
-                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./SshSpec.hs",
+                    "./PipeSpec.hs", "./ReadFileSpec.hs", "./RmSpec.hs", "./RunSpec.hs", "./ShowCommandSpec.hs", "./SshSpec.hs",
                     "./TestInit.hs", "./TestMain.hs",
                     "./WhichSpec.hs", "./WriteSpec.hs", "./sleep.hs"]
 
@@ -87,13 +87,13 @@ findSpec = do
         then sort res @?= ["test/src\\CopySpec.hs", "test/src\\EnvSpec.hs", "test/src\\FailureSpec.hs",
                     "test/src\\FindSpec.hs", "test/src\\Help.hs", "test/src\\LiftedSpec.hs",
                     "test/src\\LogWithSpec.hs", "test/src\\MoveSpec.hs", "test/src\\PipeSpec.hs", "test/src\\ReadFileSpec.hs",
-                    "test/src\\RmSpec.hs", "test/src\\RunSpec.hs", "test/src\\SshSpec.hs",
+                    "test/src\\RmSpec.hs", "test/src\\RunSpec.hs", "test/src\\ShowCommandSpec.hs", "test/src\\SshSpec.hs",
                     "test/src\\TestInit.hs", "test/src\\TestMain.hs", "test/src\\WhichSpec.hs", "test/src\\WriteSpec.hs",
                     "test/src\\sleep.hs"]
         else sort res @?= ["test/src/CopySpec.hs", "test/src/EnvSpec.hs", "test/src/FailureSpec.hs",
                     "test/src/FindSpec.hs", "test/src/Help.hs", "test/src/LiftedSpec.hs",
                     "test/src/LogWithSpec.hs", "test/src/MoveSpec.hs", "test/src/PipeSpec.hs", "test/src/ReadFileSpec.hs",
-                    "test/src/RmSpec.hs", "test/src/RunSpec.hs", "test/src/SshSpec.hs",
+                    "test/src/RmSpec.hs", "test/src/RunSpec.hs", "test/src/ShowCommandSpec.hs", "test/src/SshSpec.hs",
                     "test/src/TestInit.hs", "test/src/TestMain.hs", "test/src/WhichSpec.hs", "test/src/WriteSpec.hs",
                     "test/src/sleep.hs"]
 
@@ -102,7 +102,7 @@ findSpec = do
       sort res @?= ["CopySpec.hs", "EnvSpec.hs", "FailureSpec.hs", "FindSpec.hs",
                     "Help.hs", "LiftedSpec.hs", "LogWithSpec.hs", "MoveSpec.hs",
                     "PipeSpec.hs", "ReadFileSpec.hs", "RmSpec.hs", "RunSpec.hs",
-                    "SshSpec.hs", "TestInit.hs", "TestMain.hs",
+                    "ShowCommandSpec.hs", "SshSpec.hs", "TestInit.hs", "TestMain.hs",
                     "WhichSpec.hs", "WriteSpec.hs", "sleep.hs"]
 
     unless isWindows $ before createSymlinkForTest $ do

--- a/test/src/ShowCommandSpec.hs
+++ b/test/src/ShowCommandSpec.hs
@@ -1,0 +1,37 @@
+module ShowCommandSpec (showCommandSpec) where
+
+import TestInit
+
+showCommandSpec :: Spec
+showCommandSpec = do
+  describe "show_command" $ do
+    it "preserves the empty string" $ do
+      show_command "echo" [""] @?= "echo \"\""
+
+    it "does not quote arguments that do not contain special characters" $ do
+      show_command "echo" ["a1~!@#%^-_+=:,.?/"] @?= "echo a1~!@#%^-_+=:,.?/"
+
+    it "quotes whitespace" $ do
+      show_command "echo" [" "] @?= "echo \" \""
+      show_command "echo" ["\t"] @?= "echo \"\t\""
+      show_command "echo" ["\r"] @?= "echo \"\r\""
+      show_command "echo" ["\n"] @?= "echo \"\n\""
+
+
+    it "quotes arguments that contain special characters" $ do
+      show_command "echo" ["'"] @?= "echo \"'\""
+      show_command "echo" ["&"] @?= "echo \"&\""
+      show_command "echo" ["|"] @?= "echo \"|\""
+      show_command "echo" [";"] @?= "echo \";\""
+      show_command "echo" ["("] @?= "echo \"(\""
+      show_command "echo" [")"] @?= "echo \")\""
+      show_command "echo" ["{"] @?= "echo \"{\""
+      show_command "echo" ["}"] @?= "echo \"}\""
+      show_command "echo" ["<"] @?= "echo \"<\""
+      show_command "echo" [">"] @?= "echo \">\""
+
+    it "escapes the few special characters that must be escaped even in quotes" $ do
+      show_command "echo" ["\""] @?= "echo \"\\\"\""
+      show_command "echo" ["\\"] @?= "echo \"\\\\\""
+      show_command "echo" ["$"] @?= "echo \"\\$\""
+      show_command "echo" ["`"] @?= "echo \"\\`\""

--- a/test/src/TestMain.hs
+++ b/test/src/TestMain.hs
@@ -12,6 +12,7 @@ import FailureSpec
 import CopySpec
 import LiftedSpec
 import RunSpec
+import ShowCommandSpec
 import SshSpec
 import PipeSpec
 
@@ -30,5 +31,6 @@ main = hspec $ do
     copySpec
     liftedSpec
     runSpec
+    showCommandSpec
     sshSpec
     pipeSpec


### PR DESCRIPTION
Previously, there were bugs like `hey 'there` would be left as is and not escaped.

This will escape `hey 'there` as `"hey 'there"`. It handles special characters and only quotes when necessary.