### PR TITLE
Avoid async exceptions footgun in `shelly'`

### DIFF
--- a/shelly.cabal
+++ b/shelly.cabal
@@ -90,6 +90,7 @@ Library
     , directory                 >= 1.3.0.0   && < 1.4
     , enclosed-exceptions       >= 1.0.1
     , exceptions                >= 0.10.0
+    , safe-exceptions           >= 0.1
     , filepath                  >= 1.4.1.1
     , lifted-base               >= 0.2.3.2
     , monad-control             >= 0.3.2     && < 1.1

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -392,7 +392,7 @@ run_sudo cmd args = Sudo $ run "/usr/bin/sudo" (cmd:args)
 catch_sh :: (Exception e) => Sh a -> (e -> Sh a) -> Sh a
 catch_sh action handler = do
     ref <- ask
-    liftIO $ catch (runSh action ref) (\e -> runSh (handler e) ref)
+    liftIO $ Safe.catch (runSh action ref) (\e -> runSh (handler e) ref)
 
 -- | Same as a normal 'handle' but specialized for the Sh monad.
 handle_sh :: (Exception e) => (e -> Sh a) -> Sh a -> Sh a

--- a/src/Shelly.hs
+++ b/src/Shelly.hs
@@ -104,6 +104,7 @@ import Control.Applicative
 import Control.Concurrent
 import Control.Concurrent.Async (async, wait, Async)
 import Control.Exception
+import qualified Control.Exception.Safe as Safe
 import Control.Monad ( when, unless, void, liftM2 )
 import Control.Monad.Trans ( MonadIO )
 import Control.Monad.Reader (ask)
@@ -423,10 +424,10 @@ catches_sh :: Sh a -> [ShellyHandler a] -> Sh a
 catches_sh action handlers = do
     ref <- ask
     let runner a = runSh a ref
-    liftIO $ catches (runner action) $ map (toHandler runner) handlers
+    liftIO $ Safe.catches (runner action) $ map (toHandler runner) handlers
   where
-    toHandler :: (Sh a -> IO a) -> ShellyHandler a -> Handler a
-    toHandler runner (ShellyHandler handler) = Handler (\e -> runner (handler e))
+    toHandler :: (Sh a -> IO a) -> ShellyHandler a -> Safe.Handler IO a
+    toHandler runner (ShellyHandler handler) = Safe.Handler (\e -> runner (handler e))
 
 -- | Catch any exception in the 'Sh' monad.
 catchany_sh :: Sh a -> (SomeException -> Sh a) -> Sh a

--- a/src/Shelly/Base.hs
+++ b/src/Shelly/Base.hs
@@ -48,7 +48,8 @@ import qualified System.Directory as FS
 import Data.IORef (readIORef, modifyIORef, IORef)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import Control.Exception (SomeException, catch, throwIO, Exception)
+import Control.Exception (SomeException, throwIO, Exception)
+import qualified Control.Exception.Safe as Safe
 import Data.Maybe (fromMaybe)
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Trans ( MonadIO, liftIO )
@@ -87,7 +88,7 @@ instance Catch.MonadThrow Sh where
 
 instance Catch.MonadCatch Sh where
   catch (Sh (ReaderT m)) c =
-      Sh $ ReaderT $ \r -> m r `Catch.catch` \e -> runSh (c e) r
+      Sh $ ReaderT $ \r -> m r `Safe.catch` \e -> runSh (c e) r
 
 runSh :: Sh a -> IORef State -> IO a
 runSh = runReaderT . unSh
@@ -315,4 +316,4 @@ traceEcho msg = trace ("echo " `mappend` "'" `mappend` msg `mappend` "'")
 -- | A helper to catch any exception (same as
 -- @... `catch` \(e :: SomeException) -> ...@).
 catchany :: IO a -> (SomeException -> IO a) -> IO a
-catchany = catch
+catchany = Safe.catch


### PR DESCRIPTION
This PR uses `catch` and `catches` from the `safe-exceptions` library in a few places, notably in `catches_sh`, which is run as part of `shelly'`.

Without this commit, if a `Sh` computation were being run as part of an async computation (say, a `snap` web handler) if we had an async exception being thrown by the main handler, it would be caught by `catches_sh` and rethrown as a sync exception via `ReThrownException`, meaning that if the caller of `shelly` had an exception handler like `try` _even_ if it came from the `safe-exceptions` library, this would be now be exercised because the exception got converted into a synchronous one.

This is especially problematic because it hides the real culprit; a user might be misled thinking this was an exception coming from the guts of the `shelly` computation, whereas it was not.

@andreasabel I know that dealing with exceptions (especially async ones) is always a bit of an headache, but does this sound sensible to you? I have verified in some upstream code that now the latter exhibit the correct behavior (i.e. the `try` doesn't catch it, and the exception is correctly propagated up the ladder).