### PR TITLE
Bump CI to GHC 9.14.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250821
+# version: 0.19.20260128
 #
-# REGENDATA ("0.19.20250821",["github","shelly.cabal"])
+# REGENDATA ("0.19.20260128",["github","shelly.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,10 +35,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.14.0.20250819
+          - compiler: ghc-9.14.1
             compilerKind: ghc
-            compilerVersion: 9.14.0.20250819
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.14.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
@@ -126,21 +129,6 @@ jobs:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
           HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
@@ -151,7 +139,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -179,18 +167,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -214,7 +190,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -246,9 +222,6 @@ jobs:
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(shelly)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -257,7 +230,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -288,7 +261,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         plan:
-          - ghc: '9.12.2'
-            resolver: 'nightly-2025-08-23'
-          - ghc: '9.10.2'
-            resolver: 'lts-24.6'
+          - ghc: '9.12.4'
+            resolver: 'nightly-2026-04-01'
+          - ghc: '9.10.3'
+            resolver: 'lts-24.35'
           - ghc: '9.8.4'
             resolver: 'lts-23.28'
           - ghc: '9.6.7'
@@ -41,20 +41,20 @@ jobs:
         include:
           - os: windows-latest
             plan:
-              ghc: '9.12.2'
-              resolver: 'nightly-2025-08-23'
+              ghc: '9.12.4'
+              resolver: 'nightly-2026-04-01'
 
           - os: macos-latest
             plan:
-              ghc: '9.12.2'
-              resolver: 'nightly-2025-08-23'
+              ghc: '9.12.4'
+              resolver: 'nightly-2026-04-01'
 
     runs-on: ${{ matrix.os }}
     env:
       STACK: stack --system-ghc --no-terminal --resolver ${{ matrix.plan.resolver }}
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - uses: haskell-actions/setup@latest
       id: setup
@@ -63,7 +63,7 @@ jobs:
         enable-stack: true
         cabal-update: false
 
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v5
       id: cache
       env:
         key: ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}
@@ -84,7 +84,7 @@ jobs:
     - name: Test
       run: $STACK -j 1 test --haddock --no-haddock-deps
 
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v5
       if: always() && steps.cache.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.setup.outputs.stack-root }}


### PR DESCRIPTION
Haskell-CI for GHC 9.14.1 seems to be blocked on missing bound relaxation(s): https://github.com/gregwebs/Shelly.hs/actions/runs/23866886015/job/69588297404#step:18:30
> [__6] rejecting: unix-2.8.8.0/installed-460b (conflict: boring => base>=4.12.0.0 && <4.22, unix => base==4.22.0.0/installed-8900)
- [x] https://github.com/phadej/boring/issues/48